### PR TITLE
docs: point README at aoshima charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ Separation tracker: [dataheld/aoshima#227](https://github.com/dataheld/aoshima/i
 
 ## Charter
 
-Read the [estate-wide Charter](https://github.com/dataheld/aoshima#charter) **before design decisions**.
-That document is the north star for this estate.
-This repo does not keep a second manifesto.
+This repo contributes to the broader IT infrastructure laid out in [aoshima](https://github.com/dataheld/aoshima).
+When making changes, adhere to [aoshima's charter](https://github.com/dataheld/aoshima#charter).
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ It is **not**:
 
 Separation tracker: [dataheld/aoshima#227](https://github.com/dataheld/aoshima/issues/227).
 
+## Charter
+
+Read the [estate-wide Charter](https://github.com/dataheld/aoshima#charter) **before design decisions**.
+That document is the north star for this estate.
+This repo does not keep a second manifesto.
+
 ## Installing
 
 > [!NOTE]


### PR DESCRIPTION
This repo contributes to the broader IT infrastructure laid out in [aoshima](https://github.com/dataheld/aoshima). When making changes, adhere to [aoshima's charter](https://github.com/dataheld/aoshima#charter).

Closes #149.
Related: [dataheld/aoshima#235](https://github.com/dataheld/aoshima/issues/235)
